### PR TITLE
update to golang:latest, vim8, vim-plug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:wheezy
+FROM golang:latest
 MAINTAINER Michele Bertasi
 
 ADD fs/ /
@@ -14,7 +14,7 @@ RUN apt-get update                                                      && \
     cd vim                                                              && \
     ./configure --with-features=huge --enable-luainterp                    \
         --enable-gui=no --without-x --prefix=/usr                       && \
-    make VIMRUNTIMEDIR=/usr/share/vim/vim74                             && \
+    make VIMRUNTIMEDIR=/usr/share/vim/vim80                             && \
     make install                                                        && \
 # get go tools
     go get golang.org/x/tools/cmd/godoc                                 && \
@@ -41,22 +41,6 @@ USER dev
 ENV HOME /home/dev
 
 # install vim plugins
-RUN mkdir -p ~/.vim/bundle                                              && \
-    cd  ~/.vim/bundle                                                   && \
-    git clone --depth 1 https://github.com/gmarik/Vundle.vim.git        && \
-    git clone --depth 1 https://github.com/fatih/vim-go.git             && \
-    git clone --depth 1 https://github.com/majutsushi/tagbar.git        && \
-    git clone --depth 1 https://github.com/Shougo/neocomplete.vim.git   && \
-    git clone --depth 1 https://github.com/scrooloose/nerdtree.git      && \
-    git clone --depth 1 https://github.com/bling/vim-airline.git        && \
-    git clone --depth 1 https://github.com/tpope/vim-fugitive.git       && \
-    git clone --depth 1 https://github.com/jistr/vim-nerdtree-tabs.git  && \
-    git clone --depth 1 https://github.com/mbbill/undotree.git          && \
-    git clone --depth 1 https://github.com/Lokaltog/vim-easymotion.git  && \
-    git clone --depth 1 https://github.com/scrooloose/nerdcommenter.git && \
-    vim +PluginInstall +qall                                            && \
-# cleanup
-    rm -rf Vundle.vim/.git vim-go/.git tagbar/.git neocomplete.vim/.git    \
-        nerdtree/.git vim-airline/.git vim-fugitive/.git                   \
-        vim-nerdtree-tabs/.git undotree/.git vim-easymotion/.git           \
-        nerdcommenter/.git
+RUN curl -fLo ~/.vim/autoload/plug.vim --create-dirs \
+    https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim && \
+    vim +PlugInstall +qall

--- a/fs/home/dev/.vimrc
+++ b/fs/home/dev/.vimrc
@@ -1,28 +1,21 @@
-set nocompatible              " be iMproved, required
-filetype off                  " required
+set nocompatible              " be iMproved
 
-" set the runtime path to include Vundle and initialize
-set rtp+=~/.vim/bundle/Vundle.vim
-call vundle#begin()
-
-" let Vundle manage Vundle, required
-Plugin 'gmarik/Vundle.vim'
+call plug#begin()
 
 " custom plugins
-Plugin 'fatih/vim-go'
-Plugin 'majutsushi/tagbar'
-Plugin 'shougo/neocomplete.vim'
-Plugin 'scrooloose/nerdtree'
-Plugin 'bling/vim-airline'
-Plugin 'tpope/vim-fugitive'
-Plugin 'jistr/vim-nerdtree-tabs'
-Plugin 'mbbill/undotree'
-Plugin 'Lokaltog/vim-easymotion'
-Plugin 'scrooloose/nerdcommenter'
+Plug 'fatih/vim-go'
+Plug 'majutsushi/tagbar'
+Plug 'shougo/neocomplete.vim'
+Plug 'scrooloose/nerdtree'
+Plug 'bling/vim-airline'
+Plug 'tpope/vim-fugitive'
+Plug 'jistr/vim-nerdtree-tabs'
+Plug 'mbbill/undotree'
+Plug 'Lokaltog/vim-easymotion'
+Plug 'scrooloose/nerdcommenter'
 
 " all of your Plugins must be added before the following line
-call vundle#end()            " required
-filetype plugin indent on    " required
+call plug#end()            " required
 
 " general customizations
 syntax on


### PR DESCRIPTION
This upgrades the base image to 'golang:latest' for go1.8, updates vim to version 8.0, and replaces Vundle with [vim-plug](https://github.com/junegunn/vim-plug) for easier setup and faster plugin installation.